### PR TITLE
add slice escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The code was updated to use `oneOf` primary keys (pk and composite) to keep backward compatibility. Therefore, substreams using older versions of `DatabaseChange` can still use newer versions of `postgres-sink` without problems. 
 
+* Added escape to value in case the postgres data type is `BYTES`. We now escape the byte array.
+
 
 ## v2.2.1
 

--- a/db/operations.go
+++ b/db/operations.go
@@ -165,6 +165,10 @@ func normalizeValueType(value string, valueType reflect.Type) (string, error) {
 	switch valueType.Kind() {
 	case reflect.String:
 		return escapeStringValue(value), nil
+	// BYTES in Postgres must be escaped, we receive a Vec<u8> from substreams
+	case reflect.Slice:
+		return escapeStringValue(value), nil
+
 	case reflect.Bool:
 		return fmt.Sprintf("'%s'", value), nil
 


### PR DESCRIPTION
When trying to use BYTES column in postgres, substreams uses Vec and the conversion process to Go translates to a Slice. Postgres needs escaped bytes the same as strings.