### PR TITLE
update schema to fix errors with clickhouse 23.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Bump version of `schema` dependency to fix errors with newere Clickhouse versions now using `system.tables` table instead of `information_schema.tables` view. 
 
 ## v4.0.0-rc.3
 
@@ -63,7 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v3.0.3
 
 * Fixed missing uint8 and uint16 cast for clickhouse driver conversion
-* Bump version of `schema` dependency to fix errors with Clickhouse 23.9 enums being updated to String representation and not numbers.
 
 ## v3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v3.0.3
 
 * Fixed missing uint8 and uint16 cast for clickhouse driver conversion
+* Bump version of `schema` dependency to fix errors with Clickhouse 23.9 enums being updated to String representation and not numbers.
 
 ## v3.0.2
 

--- a/go.mod
+++ b/go.mod
@@ -168,4 +168,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/jimsmart/schema => github.com/semiotic-ai/schema v0.0.0-20231013140230-ca2e893c4ab1
+replace github.com/jimsmart/schema => github.com/semiotic-ai/schema v0.0.0-20231204185452-913e2b1c41d6
+

--- a/go.mod
+++ b/go.mod
@@ -168,4 +168,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/jimsmart/schema => github.com/semiotic-ai/schema v0.0.0-20230727171059-24e630184512
+replace github.com/jimsmart/schema => github.com/semiotic-ai/schema v0.0.0-20231013140230-ca2e893c4ab1

--- a/go.sum
+++ b/go.sum
@@ -629,6 +629,7 @@ github.com/googleapis/gax-go/v2 v2.11.0/go.mod h1:DxmR61SGKkGLa2xigwuZIQpkCI2S5i
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
@@ -676,6 +677,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -867,6 +869,7 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88J
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
@@ -1111,6 +1114,8 @@ github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/semiotic-ai/schema v0.0.0-20230727171059-24e630184512 h1:OYGti3Jz92zL6cFBDLt6smIjeRzPziOyy2zpZWqxUGA=
 github.com/semiotic-ai/schema v0.0.0-20230727171059-24e630184512/go.mod h1:dwA6tLbVjXHg8H9yXxUTdmwo77miO9m8NBqyhlGK074=
+github.com/semiotic-ai/schema v0.0.0-20231013140230-ca2e893c4ab1 h1:j672F1H/pZAmTiJVF8f2oxdKhWvtKkRfSZHY5rs42/E=
+github.com/semiotic-ai/schema v0.0.0-20231013140230-ca2e893c4ab1/go.mod h1:dwA6tLbVjXHg8H9yXxUTdmwo77miO9m8NBqyhlGK074=
 github.com/sethvargo/go-retry v0.2.3 h1:oYlgvIvsju3jNbottWABtbnoLC+GDtLdBHxKWxQm/iU=
 github.com/sethvargo/go-retry v0.2.3/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shirou/gopsutil v2.19.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/go.sum
+++ b/go.sum
@@ -1116,6 +1116,8 @@ github.com/semiotic-ai/schema v0.0.0-20230727171059-24e630184512 h1:OYGti3Jz92zL
 github.com/semiotic-ai/schema v0.0.0-20230727171059-24e630184512/go.mod h1:dwA6tLbVjXHg8H9yXxUTdmwo77miO9m8NBqyhlGK074=
 github.com/semiotic-ai/schema v0.0.0-20231013140230-ca2e893c4ab1 h1:j672F1H/pZAmTiJVF8f2oxdKhWvtKkRfSZHY5rs42/E=
 github.com/semiotic-ai/schema v0.0.0-20231013140230-ca2e893c4ab1/go.mod h1:dwA6tLbVjXHg8H9yXxUTdmwo77miO9m8NBqyhlGK074=
+github.com/semiotic-ai/schema v0.0.0-20231204185452-913e2b1c41d6 h1:SS6C0GUr75PJoMp6OHxGjPiiLJqWTM+QsQAg4ucsrDQ=
+github.com/semiotic-ai/schema v0.0.0-20231204185452-913e2b1c41d6/go.mod h1:dwA6tLbVjXHg8H9yXxUTdmwo77miO9m8NBqyhlGK074=
 github.com/sethvargo/go-retry v0.2.3 h1:oYlgvIvsju3jNbottWABtbnoLC+GDtLdBHxKWxQm/iU=
 github.com/sethvargo/go-retry v0.2.3/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shirou/gopsutil v2.19.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=


### PR DESCRIPTION
https://github.com/ClickHouse/ClickHouse/blob/master/CHANGELOG.md#improvement

Clickhouse on version 23.9 updated information_schema.tables.table_type from Enum8 to String. Now using the original table instead of the View makes it compatible with LTS versions: 23.3, 23.8 and newer versions.