### PR TITLE
Add dsn test for blank password

### DIFF
--- a/db/dsn_test.go
+++ b/db/dsn_test.go
@@ -14,18 +14,35 @@ func TestParseDSN(t *testing.T) {
 		expectError      bool
 		expectConnString string
 		expectSchema     string
+		expectPassword   string
 	}{
 		{
 			name:             "golden path",
 			dns:              "psql://postgres:postgres@localhost/substreams-dev?enable_incremental_sort=off&sslmode=disable",
 			expectConnString: "host=localhost port=5432 user=postgres dbname=substreams-dev enable_incremental_sort=off sslmode=disable password=postgres",
 			expectSchema:     "public",
+			expectPassword:   "postgres",
 		},
 		{
 			name:             "with schema",
 			dns:              "psql://postgres:postgres@localhost/substreams-dev?enable_incremental_sort=off&sslmode=disable&schema=foo",
 			expectConnString: "host=localhost port=5432 user=postgres dbname=substreams-dev enable_incremental_sort=off  sslmode=disable password=postgres",
 			expectSchema:     "foo",
+			expectPassword:   "postgres",
+		},
+		{
+			name:             "with password",
+			dns:              "clickhouse://default:password@localhost:9000/default",
+			expectConnString: "clickhouse://default:password@localhost:9000/default",
+			expectSchema:     "default",
+			expectPassword:   "password",
+		},
+		{
+			name:             "with blank password",
+			dns:              "clickhouse://default:@localhost:9000/default",
+			expectConnString: "clickhouse://default:@localhost:9000/default",
+			expectSchema:     "default",
+			expectPassword:   "",
 		},
 	}
 	for _, test := range tests {
@@ -37,6 +54,7 @@ func TestParseDSN(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, test.expectConnString, d.ConnString())
 				assert.Equal(t, test.expectSchema, d.schema)
+				assert.Equal(t, test.expectPassword, d.password)
 			}
 		})
 	}


### PR DESCRIPTION
Seems to be handling blank password correctly

Not sure what would be the cause of this issue: https://github.com/streamingfast/substreams-sink-sql/issues/57

