### PR TITLE
build: install from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+PROJECT_NAME = substreams-sink-sql
+DATE := $(shell date '+%Y-%m-%dT%H:%M:%S')
+HEAD = $(shell git rev-parse HEAD)
+LD_FLAGS = -X main.version=$(shell git describe --tags --always --dirty) -X main.commit=$(shell git rev-parse HEAD) -X main.date=$(DATE)
+BUILD_FLAGS = -mod=readonly -ldflags='$(LD_FLAGS)'
+BUILD_FOLDER = .
+
+
+install:
+	@echo Installing $(PROJECT_NAME)...
+	@go install $(BUILD_FLAGS) ./...
+
+uninstall:
+	@echo Uninstalling $(PROJECT_NAME)...
+	@rm -rf $(GOPATH)/bin/$(PROJECT_NAME)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ The Substreams:SQL sink helps you quickly and easily sync Substreams modules to 
 
    > **Note** Or install from source directly `go install github.com/streamingfast/substreams-sink-sql/cmd/substreams-sink-sql@latest`.
 
+Install from source:
+
+```bash
+make install
+```
+
 1. Compile the [Substreams](./docs/tutorial/substreams.yaml) tutorial project:
 
    ```bash


### PR DESCRIPTION
I noticed that installing directly from source via go install does not work. 

I think it will be useful to install the package through the makefile. Inside is the same go install but with the right flags :) 

