### PR TITLE
Ignore ClickHouse AggregateFunction column types when fetching table schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Clickhouse & `substreams-sink-sql run`
+
+* Skip `AggregateFunction` columns on Clickhouse when describing the schema.
+
 ## v4.6.6
 
 ### `substreams-sink-sql run`

--- a/db_changes/db/db.go
+++ b/db_changes/db/db.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"strings"
 
 	"github.com/jimsmart/schema"
 	"github.com/streamingfast/logging"
@@ -188,7 +187,7 @@ func (l *Loader) getTablesFromSchema(schemaName string) (map[[2]string][]*sql.Co
 		}
 
 		// Get column information for this table
-		columns, err := l.getTableColumns(schemaName, tableName)
+		columns, err := l.dialect.GetTableColumns(l.DB, schemaName, tableName)
 		if err != nil {
 			l.logger.Warn("failed to get columns for table, skipping",
 				zap.String("schema", schemaName),
@@ -207,58 +206,6 @@ func (l *Loader) getTablesFromSchema(schemaName string) (map[[2]string][]*sql.Co
 	}
 
 	return result, nil
-}
-
-// getTableColumns returns column information for a specific table, excluding AggregateFunction columns
-func (l *Loader) getTableColumns(schemaName, tableName string) ([]*sql.ColumnType, error) {
-	// First, get column information using DESCRIBE TABLE
-	describeQuery := fmt.Sprintf("DESCRIBE TABLE %s.%s",
-		EscapeIdentifier(schemaName),
-		EscapeIdentifier(tableName))
-
-	describeRows, err := l.DB.Query(describeQuery)
-	if err != nil {
-		return nil, fmt.Errorf("describing table structure: %w", err)
-	}
-	defer describeRows.Close()
-
-	var nonAggregateColumns []string
-
-	// Parse DESCRIBE results to filter out AggregateFunction columns
-	for describeRows.Next() {
-		var name, dataType, defaultKind, defaultExpression, comment, codecExpression, ttlExpression string
-		err := describeRows.Scan(&name, &dataType, &defaultKind, &defaultExpression, &comment, &codecExpression, &ttlExpression)
-		if err != nil {
-			return nil, fmt.Errorf("scanning describe results: %w", err)
-		}
-
-		if !strings.Contains(dataType, "AggregateFunction") {
-			nonAggregateColumns = append(nonAggregateColumns, EscapeIdentifier(name))
-		}
-	}
-
-	if err := describeRows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating describe results: %w", err)
-	}
-
-	if len(nonAggregateColumns) == 0 {
-		return nil, fmt.Errorf("no non-aggregate columns found in table %s.%s", schemaName, tableName)
-	}
-
-	// Now query for column types with only the non-aggregate columns
-	columnList := strings.Join(nonAggregateColumns, ", ")
-	selectQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE 1=0",
-		columnList,
-		EscapeIdentifier(schemaName),
-		EscapeIdentifier(tableName))
-
-	rows, err := l.DB.Query(selectQuery)
-	if err != nil {
-		return nil, fmt.Errorf("querying filtered table structure: %w", err)
-	}
-	defer rows.Close()
-
-	return rows.ColumnTypes()
 }
 
 func (l *Loader) LoadTables(schemaName string, cursorTableName string, historyTableName string) error {

--- a/db_changes/db/db.go
+++ b/db_changes/db/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"strings"
 
 	"github.com/jimsmart/schema"
 	"github.com/streamingfast/logging"
@@ -208,16 +209,52 @@ func (l *Loader) getTablesFromSchema(schemaName string) (map[[2]string][]*sql.Co
 	return result, nil
 }
 
-// getTableColumns returns column information for a specific table
+// getTableColumns returns column information for a specific table, excluding AggregateFunction columns
 func (l *Loader) getTableColumns(schemaName, tableName string) ([]*sql.ColumnType, error) {
-	// Use a simple query to get column information
-	query := fmt.Sprintf("SELECT * FROM %s.%s WHERE 1=0",
+	// First, get column information using DESCRIBE TABLE
+	describeQuery := fmt.Sprintf("DESCRIBE TABLE %s.%s",
 		EscapeIdentifier(schemaName),
 		EscapeIdentifier(tableName))
 
-	rows, err := l.DB.Query(query)
+	describeRows, err := l.DB.Query(describeQuery)
 	if err != nil {
-		return nil, fmt.Errorf("querying table structure: %w", err)
+		return nil, fmt.Errorf("describing table structure: %w", err)
+	}
+	defer describeRows.Close()
+
+	var nonAggregateColumns []string
+
+	// Parse DESCRIBE results to filter out AggregateFunction columns
+	for describeRows.Next() {
+		var name, dataType, defaultKind, defaultExpression, comment, codecExpression, ttlExpression string
+		err := describeRows.Scan(&name, &dataType, &defaultKind, &defaultExpression, &comment, &codecExpression, &ttlExpression)
+		if err != nil {
+			return nil, fmt.Errorf("scanning describe results: %w", err)
+		}
+
+		if !strings.Contains(dataType, "AggregateFunction") {
+			nonAggregateColumns = append(nonAggregateColumns, EscapeIdentifier(name))
+		}
+	}
+
+	if err := describeRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating describe results: %w", err)
+	}
+
+	if len(nonAggregateColumns) == 0 {
+		return nil, fmt.Errorf("no non-aggregate columns found in table %s.%s", schemaName, tableName)
+	}
+
+	// Now query for column types with only the non-aggregate columns
+	columnList := strings.Join(nonAggregateColumns, ", ")
+	selectQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE 1=0",
+		columnList,
+		EscapeIdentifier(schemaName),
+		EscapeIdentifier(tableName))
+
+	rows, err := l.DB.Query(selectQuery)
+	if err != nil {
+		return nil, fmt.Errorf("querying filtered table structure: %w", err)
 	}
 	defer rows.Close()
 

--- a/db_changes/db/dialect.go
+++ b/db_changes/db/dialect.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	sink "github.com/streamingfast/substreams-sink"
@@ -29,4 +30,5 @@ type Dialect interface {
 	OnlyInserts() bool
 	AllowPkDuplicates() bool
 	CreateUser(tx Tx, ctx context.Context, l *Loader, username string, password string, database string, readOnly bool) error
+	GetTableColumns(db *sql.DB, schemaName, tableName string) ([]*sql.ColumnType, error)
 }

--- a/db_changes/db/dialect_clickhouse.go
+++ b/db_changes/db/dialect_clickhouse.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -120,7 +121,6 @@ func (d ClickhouseDialect) GetCreateHistoryQuery(schema string, withPostgraphile
 }
 
 func (d ClickhouseDialect) ExecuteSetupScript(ctx context.Context, l *Loader, schemaSql string) error {
-
 	if d.cluster != "" {
 		stmts, err := clickhouse.NewParser(schemaSql).ParseStmts()
 		if err != nil {
@@ -367,4 +367,55 @@ func convertToType(value string, valueType reflect.Type) (any, error) {
 	default:
 		return value, nil
 	}
+}
+
+func (d ClickhouseDialect) GetTableColumns(db *sql.DB, schemaName, tableName string) ([]*sql.ColumnType, error) {
+	// For ClickHouse, use DESCRIBE TABLE to filter out AggregateFunction columns
+	describeQuery := fmt.Sprintf("DESCRIBE TABLE %s.%s",
+		EscapeIdentifier(schemaName),
+		EscapeIdentifier(tableName))
+
+	describeRows, err := db.Query(describeQuery)
+	if err != nil {
+		return nil, fmt.Errorf("describing table structure: %w", err)
+	}
+	defer describeRows.Close()
+
+	var nonAggregateColumns []string
+
+	// Parse DESCRIBE results to filter out AggregateFunction columns
+	for describeRows.Next() {
+		var name, dataType, defaultKind, defaultExpression, comment, codecExpression, ttlExpression string
+		err := describeRows.Scan(&name, &dataType, &defaultKind, &defaultExpression, &comment, &codecExpression, &ttlExpression)
+		if err != nil {
+			return nil, fmt.Errorf("scanning describe results: %w", err)
+		}
+
+		if !strings.Contains(dataType, "AggregateFunction") {
+			nonAggregateColumns = append(nonAggregateColumns, EscapeIdentifier(name))
+		}
+	}
+
+	if err := describeRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating describe results: %w", err)
+	}
+
+	if len(nonAggregateColumns) == 0 {
+		return nil, fmt.Errorf("no non-aggregate columns found in table %s.%s", schemaName, tableName)
+	}
+
+	// Now query for column types with only the non-aggregate columns
+	columnList := strings.Join(nonAggregateColumns, ", ")
+	selectQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE 1=0",
+		columnList,
+		EscapeIdentifier(schemaName),
+		EscapeIdentifier(tableName))
+
+	rows, err := db.Query(selectQuery)
+	if err != nil {
+		return nil, fmt.Errorf("querying filtered table structure: %w", err)
+	}
+	defer rows.Close()
+
+	return rows.ColumnTypes()
 }

--- a/db_changes/db/dialect_postgres.go
+++ b/db_changes/db/dialect_postgres.go
@@ -585,3 +585,17 @@ func (d *PostgresDialect) normalizeValueType(value string, valueType reflect.Typ
 		return value, nil
 	}
 }
+
+func (d PostgresDialect) GetTableColumns(db *sql.DB, schemaName, tableName string) ([]*sql.ColumnType, error) {
+	query := fmt.Sprintf("SELECT * FROM %s.%s WHERE 1=0",
+		EscapeIdentifier(schemaName),
+		EscapeIdentifier(tableName))
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("querying table structure: %w", err)
+	}
+	defer rows.Close()
+
+	return rows.ColumnTypes()
+}


### PR DESCRIPTION
Exclude AggregateFunction columns from the query used for table structure detection.
These columns contain binary aggregation states that can't be directly inserted into.

This PR solves this open issue: https://github.com/streamingfast/substreams-sink-sql/issues/97