### PR TITLE
#114 Clickhouse Dialect GetTableColumns Fails To Return ColumnTypes

### DIFF
--- a/db_changes/db/db.go
+++ b/db_changes/db/db.go
@@ -173,6 +173,16 @@ func (l *Loader) getTablesFromSchema(schemaName string) (map[[2]string][]*sql.Co
 		ORDER BY table_schema, table_name
 	`
 
+	if l.dsn.Driver() == "clickhouse" {
+		query = `
+			SELECT database AS table_schema, name AS table_name
+			FROM system.tables
+			WHERE database = ?
+				AND engine NOT IN ('View', 'MaterializedView', 'Buffer')
+			ORDER BY table_schema, table_name
+		`
+	}
+
 	rows, err := l.DB.Query(query, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("querying tables: %w", err)

--- a/db_changes/db/dsn.go
+++ b/db_changes/db/dsn.go
@@ -113,10 +113,6 @@ func (c *DSN) ConnString() string {
 			// In the old code, of there was options set and the host was localhost, we were switching
 			// to host 127.0.0.1 + change of scheme to http/https, let's keep that for now
 			host = "127.0.0.1"
-			scheme = "http"
-			if c.Options.Get("secure") == "true" {
-				scheme = "https"
-			}
 		}
 
 		baseURL := fmt.Sprintf("%s://%s:%s@%s:%d/%s", scheme, c.Username, c.Password, host, c.Port, c.Database)


### PR DESCRIPTION
This addresses issue #114.
This may also not be the way that the team wishes to move forward so I will do my best to explain what I think is going on and hopefully you guys can take it from here.

When running a clickhouse sink using an HTTP connection, the go driver will not be able to determine `ColumnTypes()` and simply responds with an empty set of data... hence the bug I created yesterday.

Ok, so why not just use a TCP connection and call it a day?
That doesn't work either because the query that fetches the tables IE: `information_schema` only works over HTTP and will also crash out.

There is one more caveat... with a localhost connection we currently switch to using HTTP by default in which compounds the issue.

This PR removes the localhost hack and patches the fetching of tables for clickhouse in as surgical of a manner as possible.

Having said that... this means that the only way moving forward to run a clickhouse sink will be with a TCP connection and perhaps some additional documentations and or warnings should be added in the case this is merged. 