### PR TITLE
fix: refactor encoder to use CSV writer for row formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v4.11.0
 * Added support for nested objects in postgres from-proto mode. Table with nested objects will be created with `JSONB` type.
+* Refactor encoder to use CSV writer for row formatting.
 
 ## v4.10.0
 * Added support for one level deep nested objects in clickhouse from-proto mode. Table with nested objects will be created with `Nested` type.

--- a/db_changes/bundler/encoder.go
+++ b/db_changes/bundler/encoder.go
@@ -1,10 +1,11 @@
 package bundler
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/golang/protobuf/proto"
 )
@@ -29,12 +30,20 @@ func CSVEncode(message map[string]string) ([]byte, error) {
 	}
 	sort.Strings(keys)
 
-	var row []string
+	row := make([]string, 0, len(keys))
 	for _, key := range keys {
 		row = append(row, message[key])
 	}
-	str := strings.Join(row, ",")
-	data := []byte(str)
-	data = append(data, byte('\n'))
-	return data, nil
+
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+	if err := writer.Write(row); err != nil {
+		return nil, err
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
### 🧩 CSV Encoding Fix

The previous implementation manually joined map values with commas:

```go
str := strings.Join(row, ",")
```

This approach produced invalid CSV output when any value contained commas, quotes, or newlines — for example,
`Michael Taolor ⚡️ (τ , τ)` would break the format because the comma inside the parentheses was interpreted as a field separator.

This update replaces the manual string join with Go’s standard `encoding/csv` package, which properly escapes and quotes values according to [[RFC 4180](https://www.rfc-editor.org/rfc/rfc4180)](https://www.rfc-editor.org/rfc/rfc4180). It also ensures consistent key order by sorting map keys before encoding.
