### PR TITLE
GetTablesInSchema to ignorw materialized views, system, temporary and non-data tables

### DIFF
--- a/db_changes/db/dialect_clickhouse.go
+++ b/db_changes/db/dialect_clickhouse.go
@@ -449,9 +449,13 @@ func (d ClickhouseDialect) GetTableColumns(db *sql.DB, schemaName, tableName str
 func (d ClickhouseDialect) GetTablesInSchema(db *sql.DB, schemaName string) ([][2]string, error) {
 	// Use system.tables to query for tables in the schema
 	query := fmt.Sprintf(`
-		SELECT database as table_schema, name as table_name
+		SELECT database AS table_schema, name AS table_name
 		FROM system.tables
 		WHERE database = '%s'
+		  AND NOT is_temporary
+		  AND engine NOT LIKE '%%View'
+		  AND engine NOT LIKE 'System%%'
+		  AND has_own_data != 0
 		ORDER BY database, name
 	`, schemaName)
 

--- a/db_changes/db/dialect_clickhouse.go
+++ b/db_changes/db/dialect_clickhouse.go
@@ -451,7 +451,11 @@ func (d ClickhouseDialect) GetTablesInSchema(db *sql.DB, schemaName string) ([][
 	query := fmt.Sprintf(`
 		SELECT database as table_schema, name as table_name
 		FROM system.tables
-		WHERE database = '%s'
+		WHERE database = '%s' 
+		    AND NOT is_temporary 
+			AND engine NOT LIKE '%View'
+			AND engine NOT LIKE 'System%'
+			AND has_own_data != 0
 		ORDER BY database, name
 	`, schemaName)
 


### PR DESCRIPTION
Currently it is impossible to run silk sql against clickhouse schemas that have materialized views, due to the following error:

`unable to setup postgres sinker: load psql table: invalid table: sql sink requires a primary key in every table, none was found in table substreams_evm_tokens.mv_erc20_metadata_changes`

clickhouse views don't have primary keys. 
In previous versions streamingfast/schema was used to retrieve the list of clickhouse tables, that filtered materialized views and some other types of tables 

https://github.com/streamingfast/schema/blob/master/dialect_clickhouse.go#L11

This PR ports the filtering logic from streamingfast/schema