### PR TITLE
feat: add DELTA_UPSERT operation for atomic delta updates

### DIFF
--- a/db_changes/db/dialect_postgres.go
+++ b/db_changes/db/dialect_postgres.go
@@ -387,14 +387,14 @@ func (d PostgresDialect) saveRow(op, schema, escapedTableName string, primaryKey
 
 func (d *PostgresDialect) prepareStatement(schema string, o *Operation) (normalQuery string, undoQuery string, err error) {
 	var columns, values []string
-	if o.opType == OperationTypeInsert || o.opType == OperationTypeUpsert || o.opType == OperationTypeUpdate {
+	if o.opType == OperationTypeInsert || o.opType == OperationTypeUpsert || o.opType == OperationTypeUpdate || o.opType == OperationTypeDeltaUpsert {
 		columns, values, err = d.prepareColValues(o.table, o.data)
 		if err != nil {
 			return "", "", fmt.Errorf("preparing column & values: %w", err)
 		}
 	}
 
-	if o.opType == OperationTypeUpsert || o.opType == OperationTypeUpdate || o.opType == OperationTypeDelete {
+	if o.opType == OperationTypeUpsert || o.opType == OperationTypeUpdate || o.opType == OperationTypeDelete || o.opType == OperationTypeDeltaUpsert {
 		// A table without a primary key set yield a `primaryKey` map with a single entry where the key is an empty string
 		if _, found := o.primaryKey[""]; found {
 			return "", "", fmt.Errorf("trying to perform %s operation but table %q don't have a primary key set, this is not accepted", o.opType, o.table.name)
@@ -469,6 +469,49 @@ func (d *PostgresDialect) prepareStatement(schema string, o *Operation) (normalQ
 			return deleteQuery, d.saveDelete(schema, o.table.nameEscaped, o.primaryKey, *o.reversibleBlockNum), nil
 		}
 		return deleteQuery, "", nil
+
+	case OperationTypeDeltaUpsert:
+		// Delta upsert: numeric columns are added (values are signed)
+		updates := make([]string, len(columns))
+		for i := range columns {
+			col := columns[i]
+			// Check if column is a primary key - those use regular assignment
+			isPK := false
+			for pk := range o.primaryKey {
+				if col == EscapeIdentifier(pk) {
+					isPK = true
+					break
+				}
+			}
+			if isPK {
+				updates[i] = fmt.Sprintf("%s=EXCLUDED.%s", col, col)
+				continue
+			}
+
+			// Numeric delta: always add since value is signed (negative for subtract)
+			// balance = (COALESCE(balance::numeric, 0) + EXCLUDED.balance::numeric)::text
+			updates[i] = fmt.Sprintf("%s=(COALESCE(%s.%s::numeric, 0) + EXCLUDED.%s::numeric)::text", col, o.table.nameEscaped, col, col)
+		}
+
+		// Escape primary key column names
+		escapedPKColumns := make([]string, 0, len(o.primaryKey))
+		for pkColumn := range o.primaryKey {
+			escapedPKColumns = append(escapedPKColumns, EscapeIdentifier(pkColumn))
+		}
+		sort.Strings(escapedPKColumns)
+
+		deltaQuery := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s;",
+			o.table.identifier,
+			strings.Join(columns, ","),
+			strings.Join(values, ","),
+			strings.Join(escapedPKColumns, ","),
+			strings.Join(updates, ", "),
+		)
+
+		if o.reversibleBlockNum != nil {
+			return deltaQuery, d.saveUpsert(schema, o.table.nameEscaped, o.primaryKey, *o.reversibleBlockNum), nil
+		}
+		return deltaQuery, "", nil
 
 	default:
 		panic(fmt.Errorf("unknown operation type %q", o.opType))

--- a/db_changes/db/operations.go
+++ b/db_changes/db/operations.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
 	"regexp"
 	"strings"
@@ -18,10 +19,11 @@ type Queryable interface {
 type OperationType string
 
 const (
-	OperationTypeInsert OperationType = "INSERT"
-	OperationTypeUpsert OperationType = "UPSERT"
-	OperationTypeUpdate OperationType = "UPDATE"
-	OperationTypeDelete OperationType = "DELETE"
+	OperationTypeInsert      OperationType = "INSERT"
+	OperationTypeUpsert      OperationType = "UPSERT"
+	OperationTypeUpdate      OperationType = "UPDATE"
+	OperationTypeDelete      OperationType = "DELETE"
+	OperationTypeDeltaUpsert OperationType = "DELTA_UPSERT" // For numeric delta updates: balance = balance + delta
 )
 
 type Operation struct {
@@ -80,6 +82,17 @@ func (l *Loader) newDeleteOperation(table *TableInfo, primaryKey map[string]stri
 	}
 }
 
+func (l *Loader) newDeltaUpsertOperation(table *TableInfo, primaryKey map[string]string, data map[string]string, ordinal uint64, reversibleBlockNum *uint64) *Operation {
+	return &Operation{
+		table:              table,
+		opType:             OperationTypeDeltaUpsert,
+		primaryKey:         primaryKey,
+		data:               data,
+		ordinal:            ordinal,
+		reversibleBlockNum: reversibleBlockNum,
+	}
+}
+
 func (o *Operation) mergeData(newData map[string]string) error {
 	if o.opType == OperationTypeDelete {
 		return fmt.Errorf("unable to merge data for a delete operation")
@@ -98,6 +111,74 @@ func (o *Operation) mergeOperation(otherData map[string]string) error {
 	}
 
 	return o.mergeData(otherData)
+}
+
+// accumulateDeltas adds numeric delta values together for the same primary key
+// Used when multiple delta operations target the same row within a batch
+// Values are signed (negative for subtract, positive for add)
+func (o *Operation) accumulateDeltas(newData map[string]string) {
+	for k, v := range newData {
+		// Skip primary key columns - they don't change
+		isPK := false
+		for pk := range o.primaryKey {
+			if k == pk {
+				isPK = true
+				break
+			}
+		}
+		if isPK {
+			continue
+		}
+
+		existingStr, exists := o.data[k]
+		if !exists {
+			o.data[k] = v
+			continue
+		}
+
+		// Parse as signed decimals and add them (sign is embedded in value)
+		existingDec, err1 := parseDecimal(existingStr)
+		newDec, err2 := parseDecimal(v)
+		if err1 == nil && err2 == nil {
+			o.data[k] = existingDec.Add(newDec).String()
+		} else {
+			// Not numeric, just replace (shouldn't happen for deltas)
+			o.data[k] = v
+		}
+	}
+}
+
+func parseDecimal(s string) (decimal, error) {
+	// Simple decimal parsing - just use big.Rat for precision
+	var d decimal
+	_, ok := d.SetString(s)
+	if !ok {
+		return decimal{}, fmt.Errorf("invalid decimal: %s", s)
+	}
+	return d, nil
+}
+
+// decimal is a simple wrapper around big.Rat for delta accumulation
+type decimal struct {
+	*big.Rat
+}
+
+func (d *decimal) SetString(s string) (*decimal, bool) {
+	if d.Rat == nil {
+		d.Rat = new(big.Rat)
+	}
+	_, ok := d.Rat.SetString(s)
+	return d, ok
+}
+
+func (d decimal) Add(other decimal) decimal {
+	result := new(big.Rat)
+	result.Add(d.Rat, other.Rat)
+	return decimal{result}
+}
+
+func (d decimal) String() string {
+	return d.Rat.FloatString(18)
 }
 
 var integerRegex = regexp.MustCompile(`^\d+$`)

--- a/db_changes/db/ops.go
+++ b/db_changes/db/ops.go
@@ -277,3 +277,71 @@ func (l *Loader) Delete(tableName string, primaryKey map[string]string, reversib
 	entry.Set(uniqueID, l.newDeleteOperation(table, primaryKey, l.NextBatchOrdinal(), reversibleBlockNum))
 	return nil
 }
+
+// DeltaUpsert performs an upsert where numeric columns are added to existing values
+// instead of replacing them. Uses: col = COALESCE(col, 0) + value
+// Values are signed: negative values will subtract, positive values will add.
+func (l *Loader) DeltaUpsert(tableName string, primaryKey map[string]string, data map[string]string, reversibleBlockNum *uint64) error {
+	if l.dialect.OnlyInserts() {
+		return fmt.Errorf("delta upsert operation is not supported by the current database")
+	}
+
+	uniqueID := createRowUniqueID(primaryKey)
+	if l.tracer.Enabled() {
+		l.logger.Debug("processing delta upsert operation", zap.String("table_name", tableName), zap.String("primary_key", uniqueID), zap.Int("field_count", len(data)))
+	}
+
+	table, found := l.tables[tableName]
+	if !found {
+		return fmt.Errorf("unknown table %q", tableName)
+	}
+
+	if len(table.primaryColumns) == 0 {
+		return fmt.Errorf("trying to perform a DELTA_UPSERT operation but table %q don't have a primary key(s) set, this is not accepted", tableName)
+	}
+
+	entry, found := l.entries.Get(tableName)
+	if !found {
+		if l.tracer.Enabled() {
+			l.logger.Debug("adding tracking of table never seen before", zap.String("table_name", tableName))
+		}
+
+		entry = NewOrderedMap[string, *Operation]()
+		l.entries.Set(tableName, entry)
+	}
+
+	if op, found := entry.Get(uniqueID); found {
+		switch op.opType {
+		case OperationTypeInsert:
+			return fmt.Errorf("attempting to delta upsert an object with primary key %q, that is scheduled to be inserted", primaryKey)
+		case OperationTypeDelete:
+			return fmt.Errorf("attempting to delta upsert an object with primary key %q, that is scheduled to be deleted", primaryKey)
+		case OperationTypeUpdate, OperationTypeUpsert:
+			return fmt.Errorf("attempting to delta upsert an object with primary key %q, that is scheduled for a regular update/upsert", primaryKey)
+		case OperationTypeDeltaUpsert:
+			// Accumulate deltas: add numeric values together
+			if l.tracer.Enabled() {
+				l.logger.Debug("primary key entry already exist for delta upsert, accumulating deltas", zap.String("primary_key", uniqueID), zap.String("table_name", tableName))
+			}
+			op.accumulateDeltas(data)
+			entry.Set(uniqueID, op)
+			return nil
+		}
+	} else {
+		l.entriesCount++
+	}
+
+	if l.tracer.Enabled() {
+		l.logger.Debug("primary key entry never existed for table, adding delta upsert operation", zap.String("primary_key", uniqueID), zap.String("table_name", tableName))
+	}
+
+	// Add primary key(s) to data
+	for _, primary := range l.tables[tableName].primaryColumns {
+		if dataFromPrimaryKey, ok := primaryKey[primary.name]; ok {
+			data[primary.name] = dataFromPrimaryKey
+		}
+	}
+
+	entry.Set(uniqueID, l.newDeltaUpsertOperation(table, primaryKey, data, l.NextBatchOrdinal(), reversibleBlockNum))
+	return nil
+}

--- a/db_changes/sinker/sinker.go
+++ b/db_changes/sinker/sinker.go
@@ -305,6 +305,12 @@ func (s *SQLSinker) applyDatabaseChanges(dbChanges *pbdatabase.DatabaseChanges, 
 			if err != nil {
 				return fmt.Errorf("database delete: %w", err)
 			}
+		case pbdatabase.TableChange_OPERATION_DELTA_UPSERT:
+			// Values are signed: negative means subtract, positive means add
+			err := s.loader.DeltaUpsert(change.Table, primaryKeys, changes, reversibleBlockNum)
+			if err != nil {
+				return fmt.Errorf("database delta upsert: %w", err)
+			}
 		default:
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/streamingfast/logging v0.0.0-20251127143054-23a35e5bd633
 	github.com/streamingfast/substreams v1.16.7-0.20250925152521-9d7a8ef0f261
 	github.com/streamingfast/substreams-sink v0.5.3-0.20250818134825-6b25ffb8232c
-	github.com/streamingfast/substreams-sink-database-changes v1.3.2-0.20250509171446-cb64cdbfea72
+	github.com/streamingfast/substreams-sink-database-changes v0.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.38.0
 	github.com/testcontainers/testcontainers-go/modules/clickhouse v0.38.0
@@ -216,3 +216,5 @@ require (
 	google.golang.org/grpc v1.72.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/streamingfast/substreams-sink-database-changes => github.com/aggris2/substreams-sink-database-changes v0.0.0-20251211020242-65f2b57054d7

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/RoaringBitmap/roaring v1.9.1 h1:LXcSqGGGMKm+KAzUyWn7ZeREqoOkoMX+KwLOK1thc4I=
 github.com/RoaringBitmap/roaring v1.9.1/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/aggris2/substreams-sink-database-changes v0.0.0-20251211020242-65f2b57054d7 h1:XzU0lBzX2OfakIc+EDDOuCTHBvYOFmuzcpt2BWKVbss=
+github.com/aggris2/substreams-sink-database-changes v0.0.0-20251211020242-65f2b57054d7/go.mod h1:f51ljuUsQEYuyuDdo5BB/4AfB87QDAegy5e8p5qBxis=
 github.com/alecthomas/gometalinter v2.0.11+incompatible/go.mod h1:qfIpQGGz3d+NmgyPBqv+LSh50emm1pt72EtcX2vKYQk=
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=


### PR DESCRIPTION
Adds support for OPERATION_DELTA_UPSERT which performs atomic additive updates to numeric columns. This is useful for balance tracking where multiple operations in a block affect the same row - deltas are accumulated in the batch and applied atomically.

SQL generated: INSERT ... ON CONFLICT DO UPDATE SET
  col = (COALESCE(col::numeric, 0) + EXCLUDED.col::numeric)::text

Values are signed: negative subtracts, positive adds.

NOTE: Requires substreams-sink-database-changes fork with OPERATION_DELTA_UPSERT proto field (replace directive included for testing). Update to upstream version once that PR is merged.