### PR TITLE
Add per-field UpdateOp support for advanced database operations

### DIFF
--- a/db_changes/db/dialect_clickhouse.go
+++ b/db_changes/db/dialect_clickhouse.go
@@ -262,9 +262,10 @@ func convertOpToClickhouseValues(o *Operation) ([]any, error) {
 	values := make([]any, len(o.data))
 	for i, v := range columns {
 		if col, exists := o.table.columnsByName[v]; exists {
-			convertedType, err := convertToType(o.data[v], col.scanType)
+			fieldData := o.data[v]
+			convertedType, err := convertToType(fieldData.Value, col.scanType)
 			if err != nil {
-				return nil, fmt.Errorf("converting value %q to type %q in column %q: %w", o.data[v], col.scanType, v, err)
+				return nil, fmt.Errorf("converting value %q to type %q in column %q: %w", fieldData.Value, col.scanType, v, err)
 			}
 			values[i] = convertedType
 		} else {

--- a/db_changes/db/dialect_postgres.go
+++ b/db_changes/db/dialect_postgres.go
@@ -385,10 +385,30 @@ func (d PostgresDialect) saveRow(op, schema, escapedTableName string, primaryKey
 
 }
 
+// getResultCast returns the appropriate cast suffix for the result of arithmetic operations
+// based on the column's scan type. TEXT columns need ::text cast, numeric types don't need cast.
+func getResultCast(scanType reflect.Type) string {
+	if scanType == nil {
+		return "" // unknown type, let PostgreSQL handle it
+	}
+	switch scanType.Kind() {
+	case reflect.String:
+		return "::text" // TEXT columns need explicit cast from numeric
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "" // numeric types don't need cast, PostgreSQL will handle it
+	default:
+		return "" // unknown type, let PostgreSQL handle it
+	}
+}
+
 func (d *PostgresDialect) prepareStatement(schema string, o *Operation) (normalQuery string, undoQuery string, err error) {
 	var columns, values []string
+	var updateOps []UpdateOp
+	var scanTypes []reflect.Type
 	if o.opType == OperationTypeInsert || o.opType == OperationTypeUpsert || o.opType == OperationTypeUpdate {
-		columns, values, err = d.prepareColValues(o.table, o.data)
+		columns, values, updateOps, scanTypes, err = d.prepareColValues(o.table, o.data)
 		if err != nil {
 			return "", "", fmt.Errorf("preparing column & values: %w", err)
 		}
@@ -415,9 +435,30 @@ func (d *PostgresDialect) prepareStatement(schema string, o *Operation) (normalQ
 		return insertQuery, "", nil
 
 	case OperationTypeUpsert:
+		// Build per-field update expressions based on UpdateOp
 		updates := make([]string, len(columns))
 		for i := range columns {
-			updates[i] = fmt.Sprintf("%s=EXCLUDED.%s", columns[i], columns[i])
+			col := columns[i]
+			resultCast := getResultCast(scanTypes[i])
+			switch updateOps[i] {
+			case UpdateOpSet:
+				// Direct assignment: col = EXCLUDED.col
+				updates[i] = fmt.Sprintf("%s=EXCLUDED.%s", col, col)
+			case UpdateOpAdd:
+				// Accumulate: col = COALESCE(col, 0) + EXCLUDED.col
+				updates[i] = fmt.Sprintf("%s=(COALESCE(%s.%s::numeric, 0) + EXCLUDED.%s::numeric)%s", col, o.table.nameEscaped, col, col, resultCast)
+			case UpdateOpMax:
+				// Maximum: col = GREATEST(COALESCE(col, 0), EXCLUDED.col)
+				updates[i] = fmt.Sprintf("%s=GREATEST(COALESCE(%s.%s::numeric, 0), EXCLUDED.%s::numeric)%s", col, o.table.nameEscaped, col, col, resultCast)
+			case UpdateOpMin:
+				// Minimum: col = LEAST(COALESCE(col, 0), EXCLUDED.col)
+				updates[i] = fmt.Sprintf("%s=LEAST(COALESCE(%s.%s::numeric, 0), EXCLUDED.%s::numeric)%s", col, o.table.nameEscaped, col, col, resultCast)
+			case UpdateOpSetIfNull:
+				// Set only if NULL (first value wins): col = COALESCE(col, EXCLUDED.col)
+				updates[i] = fmt.Sprintf("%s=COALESCE(%s.%s, EXCLUDED.%s)", col, o.table.nameEscaped, col, col)
+			default:
+				updates[i] = fmt.Sprintf("%s=EXCLUDED.%s", col, col)
+			}
 		}
 
 		// Escape primary key column names to preserve case sensitivity (e.g., camelCase)
@@ -441,9 +482,31 @@ func (d *PostgresDialect) prepareStatement(schema string, o *Operation) (normalQ
 		return insertQuery, "", nil
 
 	case OperationTypeUpdate:
+		// Build per-field update expressions based on UpdateOp
 		updates := make([]string, len(columns))
-		for i := 0; i < len(columns); i++ {
-			updates[i] = fmt.Sprintf("%s=%s", columns[i], values[i])
+		for i := range columns {
+			col := columns[i]
+			val := values[i]
+			resultCast := getResultCast(scanTypes[i])
+			switch updateOps[i] {
+			case UpdateOpSet:
+				// Direct assignment: col = value
+				updates[i] = fmt.Sprintf("%s=%s", col, val)
+			case UpdateOpAdd:
+				// Accumulate: col = COALESCE(col, 0) + value
+				updates[i] = fmt.Sprintf("%s=(COALESCE(%s::numeric, 0) + %s::numeric)%s", col, col, val, resultCast)
+			case UpdateOpMax:
+				// Maximum: col = GREATEST(COALESCE(col, 0), value)
+				updates[i] = fmt.Sprintf("%s=GREATEST(COALESCE(%s::numeric, 0), %s::numeric)%s", col, col, val, resultCast)
+			case UpdateOpMin:
+				// Minimum: col = LEAST(COALESCE(col, 0), value)
+				updates[i] = fmt.Sprintf("%s=LEAST(COALESCE(%s::numeric, 0), %s::numeric)%s", col, col, val, resultCast)
+			case UpdateOpSetIfNull:
+				// Set only if NULL (first value wins): col = COALESCE(col, value)
+				updates[i] = fmt.Sprintf("%s=COALESCE(%s, %s)", col, col, val)
+			default:
+				updates[i] = fmt.Sprintf("%s=%s", col, val)
+			}
 		}
 
 		primaryKeySelector := getPrimaryKeyWhereClause(o.primaryKey, "")
@@ -475,13 +538,15 @@ func (d *PostgresDialect) prepareStatement(schema string, o *Operation) (normalQ
 	}
 }
 
-func (d *PostgresDialect) prepareColValues(table *TableInfo, colValues map[string]string) (columns []string, values []string, err error) {
+func (d *PostgresDialect) prepareColValues(table *TableInfo, colValues map[string]FieldData) (columns []string, values []string, updateOps []UpdateOp, scanTypes []reflect.Type, err error) {
 	if len(colValues) == 0 {
 		return
 	}
 
 	columns = make([]string, len(colValues))
 	values = make([]string, len(colValues))
+	updateOps = make([]UpdateOp, len(colValues))
+	scanTypes = make([]reflect.Type, len(colValues))
 
 	i := 0
 	for colName := range colValues {
@@ -491,19 +556,21 @@ func (d *PostgresDialect) prepareColValues(table *TableInfo, colValues map[strin
 	sort.Strings(columns) // sorted for determinism in tests
 
 	for i, columnName := range columns {
-		value := colValues[columnName]
+		fieldData := colValues[columnName]
 		columnInfo, found := table.columnsByName[columnName]
 		if !found {
-			return nil, nil, fmt.Errorf("cannot find column %q for table %q (valid columns are %q)", columnName, table.identifier, strings.Join(maps.Keys(table.columnsByName), ", "))
+			return nil, nil, nil, nil, fmt.Errorf("cannot find column %q for table %q (valid columns are %q)", columnName, table.identifier, strings.Join(maps.Keys(table.columnsByName), ", "))
 		}
 
-		normalizedValue, err := d.normalizeValueType(value, columnInfo.scanType)
+		normalizedValue, err := d.normalizeValueType(fieldData.Value, columnInfo.scanType)
 		if err != nil {
-			return nil, nil, fmt.Errorf("getting sql value from table %s for column %q raw value %q: %w", table.identifier, columnName, value, err)
+			return nil, nil, nil, nil, fmt.Errorf("getting sql value from table %s for column %q raw value %q: %w", table.identifier, columnName, fieldData.Value, err)
 		}
 
 		values[i] = normalizedValue
 		columns[i] = columnInfo.escapedName // escape the column name
+		updateOps[i] = fieldData.UpdateOp
+		scanTypes[i] = columnInfo.scanType
 	}
 	return
 }

--- a/db_changes/db/dialect_postgres_test.go
+++ b/db_changes/db/dialect_postgres_test.go
@@ -267,3 +267,156 @@ func TestRevertOp(t *testing.T) {
 	}
 
 }
+
+// TestPrepareStatement_UpdateOp tests SQL generation for each UpdateOp type
+func TestPrepareStatement_UpdateOp(t *testing.T) {
+	// Create a test table with numeric column
+	table := createTestTable(t, "test_table", "id", "amount")
+
+	tests := []struct {
+		name        string
+		opType      OperationType
+		updateOp    UpdateOp
+		value       string
+		expectSQL   string // substring to check in generated SQL
+	}{
+		// UPSERT with different UpdateOps
+		{
+			name:      "UPSERT SET",
+			opType:    OperationTypeUpsert,
+			updateOp:  UpdateOpSet,
+			value:     "100",
+			expectSQL: `"amount"=EXCLUDED."amount"`,
+		},
+		{
+			name:      "UPSERT ADD",
+			opType:    OperationTypeUpsert,
+			updateOp:  UpdateOpAdd,
+			value:     "100",
+			expectSQL: `"amount"=(COALESCE("test_table"."amount"::numeric, 0) + EXCLUDED."amount"::numeric)`,
+		},
+		{
+			name:      "UPSERT MAX",
+			opType:    OperationTypeUpsert,
+			updateOp:  UpdateOpMax,
+			value:     "100",
+			expectSQL: `"amount"=GREATEST(COALESCE("test_table"."amount"::numeric, 0), EXCLUDED."amount"::numeric)`,
+		},
+		{
+			name:      "UPSERT MIN",
+			opType:    OperationTypeUpsert,
+			updateOp:  UpdateOpMin,
+			value:     "100",
+			expectSQL: `"amount"=LEAST(COALESCE("test_table"."amount"::numeric, 0), EXCLUDED."amount"::numeric)`,
+		},
+		{
+			name:      "UPSERT SET_IF_NULL",
+			opType:    OperationTypeUpsert,
+			updateOp:  UpdateOpSetIfNull,
+			value:     "100",
+			expectSQL: `"amount"=COALESCE("test_table"."amount", EXCLUDED."amount")`,
+		},
+
+		// UPDATE with different UpdateOps
+		{
+			name:      "UPDATE SET",
+			opType:    OperationTypeUpdate,
+			updateOp:  UpdateOpSet,
+			value:     "100",
+			expectSQL: `"amount"=100`,
+		},
+		{
+			name:      "UPDATE ADD",
+			opType:    OperationTypeUpdate,
+			updateOp:  UpdateOpAdd,
+			value:     "100",
+			expectSQL: `"amount"=(COALESCE("amount"::numeric, 0) + 100::numeric)`,
+		},
+		{
+			name:      "UPDATE MAX",
+			opType:    OperationTypeUpdate,
+			updateOp:  UpdateOpMax,
+			value:     "100",
+			expectSQL: `"amount"=GREATEST(COALESCE("amount"::numeric, 0), 100::numeric)`,
+		},
+		{
+			name:      "UPDATE MIN",
+			opType:    OperationTypeUpdate,
+			updateOp:  UpdateOpMin,
+			value:     "100",
+			expectSQL: `"amount"=LEAST(COALESCE("amount"::numeric, 0), 100::numeric)`,
+		},
+		{
+			name:      "UPDATE SET_IF_NULL",
+			opType:    OperationTypeUpdate,
+			updateOp:  UpdateOpSetIfNull,
+			value:     "100",
+			expectSQL: `"amount"=COALESCE("amount", 100)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialect := PostgresDialect{schemaName: "public"}
+			op := &Operation{
+				table:      table,
+				opType:     tt.opType,
+				primaryKey: map[string]string{"id": "123"},
+				data: map[string]FieldData{
+					"amount": {Value: tt.value, UpdateOp: tt.updateOp},
+				},
+			}
+
+			sql, _, err := dialect.prepareStatement("public", op)
+			require.NoError(t, err)
+			assert.Contains(t, sql, tt.expectSQL, "SQL should contain expected UpdateOp clause")
+		})
+	}
+}
+
+// TestPrepareStatement_INSERT_IgnoresUpdateOp tests that INSERT ignores UpdateOp (always direct values)
+func TestPrepareStatement_INSERT_IgnoresUpdateOp(t *testing.T) {
+	table := createTestTable(t, "test_table", "id", "amount")
+
+	// For INSERT, UpdateOp should not affect the SQL - it's always a direct INSERT
+	ops := []UpdateOp{UpdateOpSet, UpdateOpAdd, UpdateOpMax, UpdateOpMin, UpdateOpSetIfNull}
+
+	for _, updateOp := range ops {
+		t.Run(updateOpName(updateOp), func(t *testing.T) {
+			dialect := PostgresDialect{schemaName: "public"}
+			op := &Operation{
+				table:      table,
+				opType:     OperationTypeInsert,
+				primaryKey: map[string]string{"id": "123"},
+				data: map[string]FieldData{
+					"amount": {Value: "100", UpdateOp: updateOp},
+				},
+			}
+
+			sql, _, err := dialect.prepareStatement("public", op)
+			require.NoError(t, err)
+			// INSERT should always be a simple INSERT regardless of UpdateOp
+			assert.Contains(t, sql, "INSERT INTO")
+			assert.Contains(t, sql, "VALUES")
+			assert.NotContains(t, sql, "ON CONFLICT", "INSERT should not have ON CONFLICT clause")
+		})
+	}
+}
+
+// createTestTable creates a TableInfo for testing with numeric columns
+func createTestTable(t *testing.T, name, pkCol string, extraCols ...string) *TableInfo {
+	t.Helper()
+	columns := make(map[string]*ColumnInfo)
+
+	// Primary key column (text)
+	columns[pkCol] = NewColumnInfo(pkCol, "text", "")
+
+	// Extra columns (numeric for UpdateOp testing)
+	for _, col := range extraCols {
+		columns[col] = NewColumnInfo(col, "numeric", int64(0))
+	}
+
+	table, err := NewTableInfo("public", name, []string{pkCol}, columns)
+	require.NoError(t, err)
+	return table
+}

--- a/db_changes/db/operations.go
+++ b/db_changes/db/operations.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
 	"regexp"
 	"strings"
@@ -24,11 +25,28 @@ const (
 	OperationTypeDelete OperationType = "DELETE"
 )
 
+// UpdateOp defines the operation to apply when updating a field on conflict
+type UpdateOp int32
+
+const (
+	UpdateOpSet       UpdateOp = 0 // Direct assignment: col = value
+	UpdateOpAdd       UpdateOp = 1 // Accumulate: col = COALESCE(col, 0) + value
+	UpdateOpMax       UpdateOp = 2 // Maximum: col = GREATEST(COALESCE(col, 0), value)
+	UpdateOpMin       UpdateOp = 3 // Minimum: col = LEAST(COALESCE(col, 0), value)
+	UpdateOpSetIfNull UpdateOp = 4 // Set only if NULL: col = COALESCE(col, value)
+)
+
+// FieldData holds a field's value and its update operation
+type FieldData struct {
+	Value    string
+	UpdateOp UpdateOp
+}
+
 type Operation struct {
 	table              *TableInfo
 	opType             OperationType
 	primaryKey         map[string]string
-	data               map[string]string
+	data               map[string]FieldData
 	ordinal            uint64
 	reversibleBlockNum *uint64 // nil if that block is known to be irreversible
 }
@@ -37,7 +55,7 @@ func (o *Operation) String() string {
 	return fmt.Sprintf("%s/%s (%s)", o.table.identifier, createRowUniqueID(o.primaryKey), strings.ToLower(string(o.opType)))
 }
 
-func (l *Loader) newInsertOperation(table *TableInfo, primaryKey map[string]string, data map[string]string, ordinal uint64, reversibleBlockNum *uint64) *Operation {
+func (l *Loader) newInsertOperation(table *TableInfo, primaryKey map[string]string, data map[string]FieldData, ordinal uint64, reversibleBlockNum *uint64) *Operation {
 	return &Operation{
 		table:              table,
 		opType:             OperationTypeInsert,
@@ -48,7 +66,7 @@ func (l *Loader) newInsertOperation(table *TableInfo, primaryKey map[string]stri
 	}
 }
 
-func (l *Loader) newUpsertOperation(table *TableInfo, primaryKey map[string]string, data map[string]string, ordinal uint64, reversibleBlockNum *uint64) *Operation {
+func (l *Loader) newUpsertOperation(table *TableInfo, primaryKey map[string]string, data map[string]FieldData, ordinal uint64, reversibleBlockNum *uint64) *Operation {
 	return &Operation{
 		table:              table,
 		opType:             OperationTypeUpsert,
@@ -59,7 +77,7 @@ func (l *Loader) newUpsertOperation(table *TableInfo, primaryKey map[string]stri
 	}
 }
 
-func (l *Loader) newUpdateOperation(table *TableInfo, primaryKey map[string]string, data map[string]string, ordinal uint64, reversibleBlockNum *uint64) *Operation {
+func (l *Loader) newUpdateOperation(table *TableInfo, primaryKey map[string]string, data map[string]FieldData, ordinal uint64, reversibleBlockNum *uint64) *Operation {
 	return &Operation{
 		table:              table,
 		opType:             OperationTypeUpdate,
@@ -80,19 +98,191 @@ func (l *Loader) newDeleteOperation(table *TableInfo, primaryKey map[string]stri
 	}
 }
 
-func (o *Operation) mergeData(newData map[string]string) error {
+func (o *Operation) mergeData(newData map[string]FieldData) error {
 	if o.opType == OperationTypeDelete {
 		return fmt.Errorf("unable to merge data for a delete operation")
 	}
 
-	for k, v := range newData {
-		o.data[k] = v
+	for k, fd := range newData {
+		existing, exists := o.data[k]
+		if !exists {
+			o.data[k] = fd
+			continue
+		}
+
+		// Validate transition based on strict rules (consistent with Rust library)
+		// SET can be followed by any op, but non-SET ops can only be followed by same type
+		if err := validateOpTransition(k, existing.UpdateOp, fd.UpdateOp); err != nil {
+			return err
+		}
+
+		// Handle each incoming operation type
+		switch fd.UpdateOp {
+		case UpdateOpSet:
+			// SET: latest value wins (only valid after SET)
+			o.data[k] = fd
+
+		case UpdateOpAdd:
+			// ADD: accumulate values (valid after SET or ADD)
+			existingDec, err1 := parseDecimal(existing.Value)
+			newDec, err2 := parseDecimal(fd.Value)
+			if err1 == nil && err2 == nil {
+				o.data[k] = FieldData{
+					Value:    existingDec.Add(newDec).String(),
+					UpdateOp: existing.UpdateOp, // Keep existing op: SET stays SET, ADD stays ADD
+				}
+			} else {
+				// Non-numeric: latest value wins
+				o.data[k] = fd
+			}
+
+		case UpdateOpMax:
+			// MAX: compute maximum (valid after SET or MAX)
+			existingDec, err1 := parseDecimal(existing.Value)
+			newDec, err2 := parseDecimal(fd.Value)
+			if err1 == nil && err2 == nil {
+				maxVal := existingDec
+				if newDec.Cmp(existingDec.Rat) > 0 {
+					maxVal = newDec
+				}
+				o.data[k] = FieldData{
+					Value:    maxVal.String(),
+					UpdateOp: UpdateOpMax,
+				}
+			} else {
+				// Non-numeric: latest value wins
+				o.data[k] = fd
+			}
+
+		case UpdateOpMin:
+			// MIN: compute minimum (valid after SET or MIN)
+			existingDec, err1 := parseDecimal(existing.Value)
+			newDec, err2 := parseDecimal(fd.Value)
+			if err1 == nil && err2 == nil {
+				minVal := existingDec
+				if newDec.Cmp(existingDec.Rat) < 0 {
+					minVal = newDec
+				}
+				o.data[k] = FieldData{
+					Value:    minVal.String(),
+					UpdateOp: UpdateOpMin,
+				}
+			} else {
+				// Non-numeric: latest value wins
+				o.data[k] = fd
+			}
+
+		case UpdateOpSetIfNull:
+			// SET_IF_NULL: keep existing value (first value wins)
+			// Field already exists, so keep it and don't overwrite
+			continue
+		}
 	}
 	return nil
 }
 
+// validateOpTransition checks if the transition from existing to incoming op is valid.
+// Returns an error for invalid transitions (consistent with Rust library strict rules).
+//
+// Valid transitions:
+//   - SET → any op: OK
+//   - ADD → ADD: OK (accumulates)
+//   - MAX → MAX: OK (computes max)
+//   - MIN → MIN: OK (computes min)
+//   - SET_IF_NULL → SET_IF_NULL: OK (first value wins)
+//
+// All other transitions are invalid.
+func validateOpTransition(fieldName string, existing, incoming UpdateOp) error {
+	// SET can be followed by any operation
+	if existing == UpdateOpSet {
+		return nil
+	}
+
+	// Non-SET ops can only be followed by the same op type
+	if existing == incoming {
+		return nil
+	}
+
+	// Invalid transition
+	return fmt.Errorf(
+		"invalid UpdateOp transition for field %q: cannot apply %s after %s (only %s → %s or SET → %s is allowed)",
+		fieldName,
+		updateOpName(incoming),
+		updateOpName(existing),
+		updateOpName(existing),
+		updateOpName(existing),
+		updateOpName(incoming),
+	)
+}
+
+func updateOpName(op UpdateOp) string {
+	switch op {
+	case UpdateOpSet:
+		return "SET"
+	case UpdateOpAdd:
+		return "ADD"
+	case UpdateOpMax:
+		return "MAX"
+	case UpdateOpMin:
+		return "MIN"
+	case UpdateOpSetIfNull:
+		return "SET_IF_NULL"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", op)
+	}
+}
+
+func parseDecimal(s string) (decimal, error) {
+	// Simple decimal parsing - just use big.Rat for precision
+	var d decimal
+	_, ok := d.SetString(s)
+	if !ok {
+		return decimal{}, fmt.Errorf("invalid decimal: %s", s)
+	}
+	return d, nil
+}
+
+// decimal is a simple wrapper around big.Rat for delta accumulation
+type decimal struct {
+	*big.Rat
+}
+
+func (d *decimal) SetString(s string) (*decimal, bool) {
+	if d.Rat == nil {
+		d.Rat = new(big.Rat)
+	}
+	_, ok := d.Rat.SetString(s)
+	return d, ok
+}
+
+func (d decimal) Add(other decimal) decimal {
+	result := new(big.Rat)
+	result.Add(d.Rat, other.Rat)
+	return decimal{result}
+}
+
+func (d decimal) Sub(other decimal) decimal {
+	result := new(big.Rat)
+	result.Sub(d.Rat, other.Rat)
+	return decimal{result}
+}
+
+func (d decimal) Neg() decimal {
+	result := new(big.Rat)
+	result.Neg(d.Rat)
+	return decimal{result}
+}
+
+func (d decimal) Sign() int {
+	return d.Rat.Sign()
+}
+
+func (d decimal) String() string {
+	return d.Rat.FloatString(18)
+}
+
 // mergeOperation merges another operation into this one, keeping the lowest ordinal
-func (o *Operation) mergeOperation(otherData map[string]string) error {
+func (o *Operation) mergeOperation(otherData map[string]FieldData) error {
 	if o.opType == OperationTypeDelete {
 		return fmt.Errorf("unable to merge operation for a delete operation")
 	}

--- a/db_changes/db/operations_test.go
+++ b/db_changes/db/operations_test.go
@@ -156,7 +156,7 @@ func TestEscapeValues(t *testing.T) {
 func Test_prepareColValues(t *testing.T) {
 	type args struct {
 		table     *TableInfo
-		colValues map[string]string
+		colValues map[string]FieldData
 	}
 	tests := []struct {
 		name        string
@@ -169,7 +169,7 @@ func Test_prepareColValues(t *testing.T) {
 			"bool true",
 			args{
 				newTable(t, "schemaName", "name", "id", NewColumnInfo("col", "bool", true)),
-				map[string]string{"col": "true"},
+				map[string]FieldData{"col": {Value: "true", UpdateOp: UpdateOpSet}},
 			},
 			[]string{`"col"`},
 			[]string{`'true'`},
@@ -180,7 +180,7 @@ func Test_prepareColValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dialect := PostgresDialect{}
 
-			gotColumns, gotValues, err := dialect.prepareColValues(tt.args.table, tt.args.colValues)
+			gotColumns, gotValues, _, _, err := dialect.prepareColValues(tt.args.table, tt.args.colValues)
 			tt.assertion(t, err)
 			assert.Equal(t, tt.wantColumns, gotColumns)
 			assert.Equal(t, tt.wantValues, gotValues)
@@ -199,4 +199,228 @@ func newTable(t *testing.T, schema, name, primaryColumn string, columnInfos ...*
 	require.NoError(t, err)
 
 	return table
+}
+
+// TestMergeData_ValidTransitions tests all valid UpdateOp transitions
+func TestMergeData_ValidTransitions(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingOp     UpdateOp
+		existingValue  string
+		incomingOp     UpdateOp
+		incomingValue  string
+		expectedValue  string
+		expectedOp     UpdateOp
+	}{
+		// SET → any (all allowed)
+		{"SET → SET", UpdateOpSet, "100", UpdateOpSet, "200", "200", UpdateOpSet},
+		{"SET → ADD", UpdateOpSet, "100", UpdateOpAdd, "50", "150.000000000000000000", UpdateOpSet},
+		{"SET → MAX", UpdateOpSet, "100", UpdateOpMax, "150", "150.000000000000000000", UpdateOpMax},
+		{"SET → MAX (existing wins)", UpdateOpSet, "200", UpdateOpMax, "150", "200.000000000000000000", UpdateOpMax},
+		{"SET → MIN", UpdateOpSet, "100", UpdateOpMin, "50", "50.000000000000000000", UpdateOpMin},
+		{"SET → MIN (existing wins)", UpdateOpSet, "50", UpdateOpMin, "100", "50.000000000000000000", UpdateOpMin},
+		{"SET → SET_IF_NULL", UpdateOpSet, "100", UpdateOpSetIfNull, "200", "100", UpdateOpSet},
+
+		// ADD → ADD (accumulates)
+		{"ADD → ADD", UpdateOpAdd, "100", UpdateOpAdd, "50", "150.000000000000000000", UpdateOpAdd},
+		{"ADD → ADD (negative)", UpdateOpAdd, "100", UpdateOpAdd, "-30", "70.000000000000000000", UpdateOpAdd},
+
+		// MAX → MAX (computes max)
+		{"MAX → MAX (new wins)", UpdateOpMax, "100", UpdateOpMax, "150", "150.000000000000000000", UpdateOpMax},
+		{"MAX → MAX (existing wins)", UpdateOpMax, "200", UpdateOpMax, "150", "200.000000000000000000", UpdateOpMax},
+
+		// MIN → MIN (computes min)
+		{"MIN → MIN (new wins)", UpdateOpMin, "100", UpdateOpMin, "50", "50.000000000000000000", UpdateOpMin},
+		{"MIN → MIN (existing wins)", UpdateOpMin, "50", UpdateOpMin, "100", "50.000000000000000000", UpdateOpMin},
+
+		// SET_IF_NULL → SET_IF_NULL (first value wins)
+		{"SET_IF_NULL → SET_IF_NULL", UpdateOpSetIfNull, "100", UpdateOpSetIfNull, "200", "100", UpdateOpSetIfNull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := &Operation{
+				opType: OperationTypeUpsert,
+				data:   map[string]FieldData{"field": {Value: tt.existingValue, UpdateOp: tt.existingOp}},
+			}
+
+			err := op.mergeData(map[string]FieldData{"field": {Value: tt.incomingValue, UpdateOp: tt.incomingOp}})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedValue, op.data["field"].Value)
+			assert.Equal(t, tt.expectedOp, op.data["field"].UpdateOp)
+		})
+	}
+}
+
+// TestMergeData_InvalidTransitions tests all invalid UpdateOp transitions return errors
+func TestMergeData_InvalidTransitions(t *testing.T) {
+	tests := []struct {
+		name       string
+		existingOp UpdateOp
+		incomingOp UpdateOp
+	}{
+		// ADD → others (except ADD)
+		{"ADD → SET", UpdateOpAdd, UpdateOpSet},
+		{"ADD → MAX", UpdateOpAdd, UpdateOpMax},
+		{"ADD → MIN", UpdateOpAdd, UpdateOpMin},
+		{"ADD → SET_IF_NULL", UpdateOpAdd, UpdateOpSetIfNull},
+
+		// MAX → others (except MAX)
+		{"MAX → SET", UpdateOpMax, UpdateOpSet},
+		{"MAX → ADD", UpdateOpMax, UpdateOpAdd},
+		{"MAX → MIN", UpdateOpMax, UpdateOpMin},
+		{"MAX → SET_IF_NULL", UpdateOpMax, UpdateOpSetIfNull},
+
+		// MIN → others (except MIN)
+		{"MIN → SET", UpdateOpMin, UpdateOpSet},
+		{"MIN → ADD", UpdateOpMin, UpdateOpAdd},
+		{"MIN → MAX", UpdateOpMin, UpdateOpMax},
+		{"MIN → SET_IF_NULL", UpdateOpMin, UpdateOpSetIfNull},
+
+		// SET_IF_NULL → others (except SET_IF_NULL)
+		{"SET_IF_NULL → SET", UpdateOpSetIfNull, UpdateOpSet},
+		{"SET_IF_NULL → ADD", UpdateOpSetIfNull, UpdateOpAdd},
+		{"SET_IF_NULL → MAX", UpdateOpSetIfNull, UpdateOpMax},
+		{"SET_IF_NULL → MIN", UpdateOpSetIfNull, UpdateOpMin},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := &Operation{
+				opType: OperationTypeUpsert,
+				data:   map[string]FieldData{"field": {Value: "100", UpdateOp: tt.existingOp}},
+			}
+
+			err := op.mergeData(map[string]FieldData{"field": {Value: "200", UpdateOp: tt.incomingOp}})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid UpdateOp transition")
+		})
+	}
+}
+
+// TestMergeData_NewField tests adding a new field (no existing)
+func TestMergeData_NewField(t *testing.T) {
+	ops := []UpdateOp{UpdateOpSet, UpdateOpAdd, UpdateOpMax, UpdateOpMin, UpdateOpSetIfNull}
+
+	for _, op := range ops {
+		t.Run(updateOpName(op), func(t *testing.T) {
+			operation := &Operation{
+				opType: OperationTypeUpsert,
+				data:   map[string]FieldData{},
+			}
+
+			err := operation.mergeData(map[string]FieldData{"field": {Value: "100", UpdateOp: op}})
+			require.NoError(t, err)
+			assert.Equal(t, "100", operation.data["field"].Value)
+			assert.Equal(t, op, operation.data["field"].UpdateOp)
+		})
+	}
+}
+
+// TestMergeData_NonNumeric tests handling of non-numeric values
+func TestMergeData_NonNumeric(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingValue string
+		incomingValue string
+		op            UpdateOp
+		expectedValue string
+	}{
+		{"ADD non-numeric", "hello", "world", UpdateOpAdd, "world"},
+		{"MAX non-numeric", "hello", "world", UpdateOpMax, "world"},
+		{"MIN non-numeric", "hello", "world", UpdateOpMin, "world"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := &Operation{
+				opType: OperationTypeUpsert,
+				data:   map[string]FieldData{"field": {Value: tt.existingValue, UpdateOp: tt.op}},
+			}
+
+			err := op.mergeData(map[string]FieldData{"field": {Value: tt.incomingValue, UpdateOp: tt.op}})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, op.data["field"].Value)
+		})
+	}
+}
+
+// TestMergeData_DecimalPrecision tests high precision decimal handling
+func TestMergeData_DecimalPrecision(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingValue  string
+		incomingValue  string
+		expectedValue  string
+	}{
+		{"small decimals", "0.000000000000000001", "0.000000000000000002", "0.000000000000000003"},
+		{"large numbers", "1000000000000000000", "1000000000000000000", "2000000000000000000.000000000000000000"},
+		{"mixed precision", "100.5", "50.25", "150.750000000000000000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := &Operation{
+				opType: OperationTypeUpsert,
+				data:   map[string]FieldData{"field": {Value: tt.existingValue, UpdateOp: UpdateOpAdd}},
+			}
+
+			err := op.mergeData(map[string]FieldData{"field": {Value: tt.incomingValue, UpdateOp: UpdateOpAdd}})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, op.data["field"].Value)
+		})
+	}
+}
+
+// TestMergeData_MultipleFields tests merging multiple fields at once
+func TestMergeData_MultipleFields(t *testing.T) {
+	op := &Operation{
+		opType: OperationTypeUpsert,
+		data: map[string]FieldData{
+			"counter":    {Value: "100", UpdateOp: UpdateOpAdd},
+			"max_price":  {Value: "50", UpdateOp: UpdateOpMax},
+			"min_price":  {Value: "100", UpdateOp: UpdateOpMin},
+			"first_seen": {Value: "2024-01-01", UpdateOp: UpdateOpSetIfNull},
+			"name":       {Value: "old", UpdateOp: UpdateOpSet},
+		},
+	}
+
+	incoming := map[string]FieldData{
+		"counter":    {Value: "50", UpdateOp: UpdateOpAdd},
+		"max_price":  {Value: "75", UpdateOp: UpdateOpMax},
+		"min_price":  {Value: "80", UpdateOp: UpdateOpMin},
+		"first_seen": {Value: "2024-02-01", UpdateOp: UpdateOpSetIfNull},
+		"name":       {Value: "new", UpdateOp: UpdateOpSet},
+	}
+
+	err := op.mergeData(incoming)
+	require.NoError(t, err)
+
+	assert.Equal(t, "150.000000000000000000", op.data["counter"].Value)
+	assert.Equal(t, UpdateOpAdd, op.data["counter"].UpdateOp)
+
+	assert.Equal(t, "75.000000000000000000", op.data["max_price"].Value)
+	assert.Equal(t, UpdateOpMax, op.data["max_price"].UpdateOp)
+
+	assert.Equal(t, "80.000000000000000000", op.data["min_price"].Value)
+	assert.Equal(t, UpdateOpMin, op.data["min_price"].UpdateOp)
+
+	assert.Equal(t, "2024-01-01", op.data["first_seen"].Value)
+	assert.Equal(t, UpdateOpSetIfNull, op.data["first_seen"].UpdateOp)
+
+	assert.Equal(t, "new", op.data["name"].Value)
+	assert.Equal(t, UpdateOpSet, op.data["name"].UpdateOp)
+}
+
+// TestMergeData_DeleteOperation tests that merging into a delete operation fails
+func TestMergeData_DeleteOperation(t *testing.T) {
+	op := &Operation{
+		opType: OperationTypeDelete,
+		data:   map[string]FieldData{},
+	}
+
+	err := op.mergeData(map[string]FieldData{"field": {Value: "100", UpdateOp: UpdateOpSet}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete operation")
 }

--- a/db_changes/db/ops.go
+++ b/db_changes/db/ops.go
@@ -11,7 +11,7 @@ import (
 
 // Insert a row in the DB, it is assumed the table exists, you can do a
 // check before with HasTable()
-func (l *Loader) Insert(tableName string, primaryKey map[string]string, data map[string]string, reversibleBlockNum *uint64) error {
+func (l *Loader) Insert(tableName string, primaryKey map[string]string, data map[string]FieldData, reversibleBlockNum *uint64) error {
 	uniqueID := createRowUniqueID(primaryKey)
 
 	if l.tracer.Enabled() {
@@ -55,7 +55,7 @@ func (l *Loader) Insert(tableName string, primaryKey map[string]string, data map
 	// We need to make sure to add the primary key(s) in the data so that those column get created correctly, but only if there is data
 	for _, primary := range l.tables[tableName].primaryColumns {
 		if dataFromPrimaryKey, ok := primaryKey[primary.name]; ok {
-			data[primary.name] = dataFromPrimaryKey
+			data[primary.name] = FieldData{Value: dataFromPrimaryKey, UpdateOp: UpdateOpSet}
 		}
 	}
 
@@ -101,7 +101,7 @@ func (l *Loader) GetPrimaryKey(tableName string, pk string) (map[string]string, 
 
 // Upsert a row in the DB, it is assumed the table exists, you can do a
 // check before with HasTable().
-func (l *Loader) Upsert(tableName string, primaryKey map[string]string, data map[string]string, reversibleBlockNum *uint64) error {
+func (l *Loader) Upsert(tableName string, primaryKey map[string]string, data map[string]FieldData, reversibleBlockNum *uint64) error {
 	if l.dialect.OnlyInserts() {
 		return fmt.Errorf("update operation is not supported by the current database")
 	}
@@ -161,7 +161,7 @@ func (l *Loader) Upsert(tableName string, primaryKey map[string]string, data map
 	// We need to make sure to add the primary key(s) in the data so that those column get created correctly, but only if there is data
 	for _, primary := range l.tables[tableName].primaryColumns {
 		if dataFromPrimaryKey, ok := primaryKey[primary.name]; ok {
-			data[primary.name] = dataFromPrimaryKey
+			data[primary.name] = FieldData{Value: dataFromPrimaryKey, UpdateOp: UpdateOpSet}
 		}
 	}
 
@@ -171,7 +171,7 @@ func (l *Loader) Upsert(tableName string, primaryKey map[string]string, data map
 
 // Update a row in the DB, it is assumed the table exists, you can do a
 // check before with HasTable()
-func (l *Loader) Update(tableName string, primaryKey map[string]string, data map[string]string, reversibleBlockNum *uint64) error {
+func (l *Loader) Update(tableName string, primaryKey map[string]string, data map[string]FieldData, reversibleBlockNum *uint64) error {
 	if l.dialect.OnlyInserts() {
 		return fmt.Errorf("update operation is not supported by the current database")
 	}
@@ -277,3 +277,4 @@ func (l *Loader) Delete(tableName string, primaryKey map[string]string, reversib
 	entry.Set(uniqueID, l.newDeleteOperation(table, primaryKey, l.NextBatchOrdinal(), reversibleBlockNum))
 	return nil
 }
+

--- a/db_changes/sinker/sinker.go
+++ b/db_changes/sinker/sinker.go
@@ -274,9 +274,12 @@ func (s *SQLSinker) applyDatabaseChanges(dbChanges *pbdatabase.DatabaseChanges, 
 			return fmt.Errorf("unknown primary key type: %T", change.PrimaryKey)
 		}
 
-		changes := map[string]string{}
+		changes := map[string]db2.FieldData{}
 		for _, field := range change.Fields {
-			changes[field.Name] = field.NewValue
+			changes[field.Name] = db2.FieldData{
+				Value:    field.NewValue,
+				UpdateOp: protoUpdateOpToDbUpdateOp(field.UpdateOp),
+			}
 		}
 
 		var reversibleBlockNum *uint64
@@ -310,6 +313,22 @@ func (s *SQLSinker) applyDatabaseChanges(dbChanges *pbdatabase.DatabaseChanges, 
 	}
 
 	return nil
+}
+
+// protoUpdateOpToDbUpdateOp converts proto Field_UpdateOp to db UpdateOp
+func protoUpdateOpToDbUpdateOp(op pbdatabase.Field_UpdateOp) db2.UpdateOp {
+	switch op {
+	case pbdatabase.Field_UPDATE_OP_ADD:
+		return db2.UpdateOpAdd
+	case pbdatabase.Field_UPDATE_OP_MAX:
+		return db2.UpdateOpMax
+	case pbdatabase.Field_UPDATE_OP_MIN:
+		return db2.UpdateOpMin
+	case pbdatabase.Field_UPDATE_OP_SET_IF_NULL:
+		return db2.UpdateOpSetIfNull
+	default:
+		return db2.UpdateOpSet
+	}
 }
 
 func (s *SQLSinker) HandleBlockRangeCompletion(ctx context.Context, cursor *sink.Cursor) error {

--- a/db_changes/sinker/sinker_test.go
+++ b/db_changes/sinker/sinker_test.go
@@ -363,3 +363,33 @@ func simpleCursor(num, finalNum uint64) string {
 		HeadBlock: blk,
 	}).ToOpaque()
 }
+
+// TestProtoUpdateOpToDbUpdateOp tests the proto-to-db UpdateOp converter
+func TestProtoUpdateOpToDbUpdateOp(t *testing.T) {
+	tests := []struct {
+		name     string
+		protoOp  pbdatabase.Field_UpdateOp
+		expected db2.UpdateOp
+	}{
+		{"SET (default)", pbdatabase.Field_UPDATE_OP_SET, db2.UpdateOpSet},
+		{"ADD", pbdatabase.Field_UPDATE_OP_ADD, db2.UpdateOpAdd},
+		{"MAX", pbdatabase.Field_UPDATE_OP_MAX, db2.UpdateOpMax},
+		{"MIN", pbdatabase.Field_UPDATE_OP_MIN, db2.UpdateOpMin},
+		{"SET_IF_NULL", pbdatabase.Field_UPDATE_OP_SET_IF_NULL, db2.UpdateOpSetIfNull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := protoUpdateOpToDbUpdateOp(tt.protoOp)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestProtoUpdateOpToDbUpdateOp_UnknownValue tests that unknown proto values default to SET
+func TestProtoUpdateOpToDbUpdateOp_UnknownValue(t *testing.T) {
+	// Test with an unknown/invalid proto value - should default to SET
+	unknownOp := pbdatabase.Field_UpdateOp(999)
+	result := protoUpdateOpToDbUpdateOp(unknownOp)
+	assert.Equal(t, db2.UpdateOpSet, result, "unknown proto values should default to SET")
+}

--- a/go.mod
+++ b/go.mod
@@ -216,3 +216,5 @@ require (
 	google.golang.org/grpc v1.72.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/streamingfast/substreams-sink-database-changes => github.com/aggris2/substreams-sink-database-changes v0.0.0-20251212101149-92bb6e02e179

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/RoaringBitmap/roaring v1.9.1 h1:LXcSqGGGMKm+KAzUyWn7ZeREqoOkoMX+KwLOK1thc4I=
 github.com/RoaringBitmap/roaring v1.9.1/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/aggris2/substreams-sink-database-changes v0.0.0-20251212101149-92bb6e02e179 h1:1th3GxO9qbHwnZ6hQhivS5DOVOWQHwk2LTyuXwULsoU=
+github.com/aggris2/substreams-sink-database-changes v0.0.0-20251212101149-92bb6e02e179/go.mod h1:f51ljuUsQEYuyuDdo5BB/4AfB87QDAegy5e8p5qBxis=
 github.com/alecthomas/gometalinter v2.0.11+incompatible/go.mod h1:qfIpQGGz3d+NmgyPBqv+LSh50emm1pt72EtcX2vKYQk=
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
@@ -626,8 +628,6 @@ github.com/streamingfast/substreams v1.16.7-0.20250925152521-9d7a8ef0f261 h1:5vk
 github.com/streamingfast/substreams v1.16.7-0.20250925152521-9d7a8ef0f261/go.mod h1:3s/qTXV85jh40Li1gbYTRtbAOyFzpaHN0Bi1OtuXIDA=
 github.com/streamingfast/substreams-sink v0.5.3-0.20250818134825-6b25ffb8232c h1:LCJhSgR7XTiKxCtIBPyoFLQdYRCbFaW8EljIL8IvaWs=
 github.com/streamingfast/substreams-sink v0.5.3-0.20250818134825-6b25ffb8232c/go.mod h1:EbwZgN7FRZY6oNBmA7ufcaHZ215nDo3ejyyasuS3xj4=
-github.com/streamingfast/substreams-sink-database-changes v1.3.2-0.20250509171446-cb64cdbfea72 h1:yjEm3ypUUxCVFiaAwHr477ClRAJXHLXX2VHzk6HsxHk=
-github.com/streamingfast/substreams-sink-database-changes v1.3.2-0.20250509171446-cb64cdbfea72/go.mod h1:f51ljuUsQEYuyuDdo5BB/4AfB87QDAegy5e8p5qBxis=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=


### PR DESCRIPTION
- SQL generation for SET, ADD, MAX, MIN, SET_IF_NULL operations
- Strict transition validation (consistent with Rust library)
- Proto conversion from Field_UpdateOp to internal UpdateOp

Note: go.mod replace directive needs to be updated once substreams-sink-database-changes PR is merged.